### PR TITLE
Update Configure new project screen

### DIFF
--- a/android/step0-native-android-project/README.md
+++ b/android/step0-native-android-project/README.md
@@ -1,4 +1,4 @@
-1. Create a new android project, set name to "ComponentCase", domain to "com.phonegapday". Click next.
+1. Create a new android project, set Application name to "ComponentCase", Company Domain to "phonegapday.com" and edit Package name to be "com.phonegapday". Click next.
 ![step1](../img/step1.png)
 2. Check "Phone and Tablet" and set Minimum SDK to API 21: Android 5.0 (Lollipop)
 ![step1](../img/step2.png)


### PR DESCRIPTION
When you set the application name to "ComponentCase" and Company domain to "phonegapday.com" it automatically sets the Package name to "com.phonegapday.componentcase". If we don't edit the package name at this step the PGDayEU16Plugin class will fail to build as it won't have an import for "MainActivity". Even when you add the import the getBookmarks and addItem methods are protected and since the classes are in different packages they won't be available.

I'm just suggesting we make this an explicit instruction here instead of running into problems later in the tutorial.